### PR TITLE
Hardcoded year removed

### DIFF
--- a/Sankey_Diagram.py
+++ b/Sankey_Diagram.py
@@ -97,16 +97,20 @@ def sankey_data(df) :
 
 # Function used to delete one final node of the sankey diagram (originally build to get rid of the money buffer)
 def sankey_fnode_delete(label, source, target, value, value_to_delete):
-    i = label.index(value_to_delete)
-    k = 0
-    while k == 0 :
-        if i in target :
-            j = target.index(i)
-            del source[j]
-            del target[j]
-            del value[j]
-        else :
-            k = 1
+    try:
+        i = label.index(value_to_delete)
+        k = 0
+        while k == 0 :
+            if i in target :
+                j = target.index(i)
+                del source[j]
+                del target[j]
+                del value[j]
+            else :
+                k = 1
+    except ValueError:
+        # If it already doesn't exist
+        pass
     return label, source, target, value
 
 # Old clean flow
@@ -140,8 +144,8 @@ def create_label(CSV_df) :
             label.append(var)
     return(label)
 
-files = {'BAL' : results_path+results_file_bal,
-         'OPTI' : results_path+results_file_opti}
+files = {'BAL'  : os.path.join(results_path, results_file_bal),
+         'OPTI' : os.path.join(results_path, results_file_opti)}
 
 color_sector = {'flow' : {'Fuel' : 'rgba(0, 255, 0, 0.4)',
                           'Elec' : 'rgba(0, 0, 255, 0.4)',

--- a/Sankey_Diagram.py
+++ b/Sankey_Diagram.py
@@ -305,7 +305,7 @@ def Plotting_oneyear_sumcountries(csv_file, Year, Options_plot) :
     countries = df['CCC'].unique().tolist()
     label2, source2, target2, value2 = [], [], [], []
     for count in countries :
-        V_FLOW_C = Import_gams(files['OPTI'], 'VFLOW_Opti_C', 'CCC', count, 'Y', '2050')
+        V_FLOW_C = Import_gams(files['OPTI'], 'VFLOW_Opti_C', 'CCC', count, 'Y', Year)
         label, source, target, value = sankey_data(V_FLOW_C)
         label, source, target, value = sankey_fnode_delete(label, source, target, value, 'Money_buffer_T')
         for i in range (len(label)) :


### PR DESCRIPTION
Also added a try-except statement for the sankey_fnode_delete function, that checks whether the value_to_delete is actually in the label.index in the first place (In the 4ac7091 commit)

EDIT: Forgot to add import os !!!! Fix this